### PR TITLE
refactor(navigation): Use `replaceAll` for auth navigation (fixes #61)

### DIFF
--- a/composeApp/src/commonMain/kotlin/ke/don/gondi/navigation/AuthScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ke/don/gondi/navigation/AuthScreen.kt
@@ -44,7 +44,7 @@ class AuthScreen : Screen {
         LaunchedEffect(state.profile) {
             state.profile?.let { profile ->
                 if (profile.avatar == null) {
-                    navigator.replaceAll(OnboardingScreen())
+                    navigator.push(OnboardingScreen())
                 } else {
                     navigator.replaceAll(HomeScreen())
                 }

--- a/composeApp/src/commonMain/kotlin/ke/don/gondi/navigation/AuthScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ke/don/gondi/navigation/AuthScreen.kt
@@ -44,7 +44,7 @@ class AuthScreen : Screen {
         LaunchedEffect(state.profile) {
             state.profile?.let { profile ->
                 if (profile.avatar == null) {
-                    navigator.push(OnboardingScreen())
+                    navigator.replaceAll(OnboardingScreen())
                 } else {
                     navigator.replaceAll(HomeScreen())
                 }

--- a/composeApp/src/commonMain/kotlin/ke/don/gondi/navigation/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ke/don/gondi/navigation/HomeScreen.kt
@@ -48,7 +48,7 @@ class HomeScreen : Screen {
         HomeContent(
             state = state,
             onEvent = ::extendedOnEvent,
-            navigateToAuth = { navigator.push(AuthScreen()) },
+            navigateToAuth = { navigator.replaceAll(AuthScreen()) },
         )
     }
 }


### PR DESCRIPTION
## 📌 What does this PR do?

<!-- Describe the purpose of this PR -->
Fixes navigation bug from home to auth

## 🧪 How was it tested?

<!-- Mention any manual/automated testing -->
Manually

## 🔨 Issue fixed

<!-- Mention The issue it fixes. Prefix with '#' -->
Fixes #61

## 🧩 Related Issues

<!-- Link to related issues or discussions -->

## 📝 Checklist

- [x] I have tested this change locally
- [x] I have updated the documentation (if needed)
- [x] I have added necessary unit tests (if needed)
- [x] I have followed the project’s coding style
- [x] I have run spotless checks and it passed

## 💬 Additional context

<!-- Add any other context or screenshots if relevant -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication and onboarding navigation to replace the current screen history when moving to sign-in or onboarding, preventing users from returning to previous screens and ensuring a cleaner, one-way flow after authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->